### PR TITLE
Fix outdated function name in comment

### DIFF
--- a/src/MFRC522v2.cpp
+++ b/src/MFRC522v2.cpp
@@ -1240,7 +1240,7 @@ void MFRC522::MIFARE_CalculateAccessBits(byte accessBitBuffer[3],  ///< Pointer 
   accessBitBuffer[0] = (~c2 & 0xF) << 4 | (~c1 & 0xF);
   accessBitBuffer[1] = c1 << 4 | (~c3 & 0xF);
   accessBitBuffer[2] = c3 << 4 | c2;
-} // End MIFARE_SetAccessBits()
+} // End MIFARE_CalculateAccessBits()
 
 /////////////////////////////////////////////////////////////////////////////////////
 // Convenience functions - does not add extra functionality


### PR DESCRIPTION
<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as much information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| Doc update?   | yes/no
| BC breaks?    | yes/no <!-- BC = backwards compatibility -->
| Deprecations? | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
